### PR TITLE
Maybe try aiosqlite instead of the standard sqlite3 module?

### DIFF
--- a/Miscellaneous/plugin.py-DZ-Issue
+++ b/Miscellaneous/plugin.py-DZ-Issue
@@ -63,7 +63,7 @@
 
 import Domoticz
 import threading
-import sqlite3
+import aiosqlite
 
 
 DB_VERSION = 0x0003
@@ -71,7 +71,7 @@ DB_VERSION = 0x0003
 class PersistingListener:
     def __init__(self, database_file):
         self._database_file = database_file
-        self._db = sqlite3.connect(database_file, detect_types=sqlite3.PARSE_DECLTYPES)
+        self._db = aiosqlite.connect(database_file, detect_types=aiosqlite.PARSE_DECLTYPES)
         self._cursor = self._db.cursor()
 
         self._enable_foreign_keys()

--- a/Miscellaneous/plugin.py-standalone
+++ b/Miscellaneous/plugin.py-standalone
@@ -65,7 +65,7 @@ import Domoticz
 import asyncio
 import threading
 import logging
-import sqlite3
+import aiosqlite
 
 # There are many different radio libraries but they all have the same API
 from zigpy_zigate.zigbee.application import ControllerApplication


### PR DESCRIPTION
Maybe worth trying aiosqlite instead of the standard sqlite3 module? aiosqlite provide an async interface to sqlite databases:

https://github.com/omnilib/aiosqlite

https://aiosqlite.omnilib.dev/en/stable/api.html

https://nackjicholson.github.io/aiosql/


@pipiche38 Just a suggestion as I do not use Domoticz myself and my coding skills suck.