### PR TITLE
Change to list znp as in zigpy-znp instead of ti_cc as in zigpy-cc

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -11,7 +11,7 @@
                     <ul style="list-style-type:square">
                         <li> ezsp: 	 Silicon Labs EmberZNet protocol (ex; Elelabs, HUSBZB-1, Telegesis). </li>
                         <li> deconz: dresden elektronik deCONZ protocol: ConBee I/II, RaspBee I/II. </li>
-                        <li> ti_cc:  Texas Instruments Z-Stack ZNP protocol (ex: CC253x, CC26x2, CC13x2). </li>
+                        <li> znp:  Texas Instruments Z-Stack ZNP protocol (ex: CC253x, CC26x2, CC13x2). </li>
                         <li> zigate: ZiGate Controller. You'll have to select between PiZiGate, ZiGate USB-TTL, ZiGate WiFi. </li>
                         <li> xbee: 	 Digi XBee ZB Coordinator Firmware protocol (Digi XBee Series 2, 2C, 3) </li>
                     </ul>


### PR DESCRIPTION
Change to list "znp" which refers to zigpy-znp instead of listing "ti_cc" which refers to zigpy-cc

At least that is how they are listed in Home Assistant GUI/docs 

https://www.home-assistant.io/integrations/zha/#configuration---gui

https://github.com/home-assistant/core/blob/ceadb0cba0f058428dbe2ef34d81ebd1b73ad29b/homeassistant/components/zha/core/const.py#L233

Follow up to https://github.com/pipiche38/Domoticz-Zigpy/pull/24 as  zigpy-cc (ti_cc) is deprecated/obsolete in favour of newer zigpy-znp